### PR TITLE
Remove unnecessary initial load request

### DIFF
--- a/src/testConverter.ts
+++ b/src/testConverter.ts
@@ -65,8 +65,6 @@ export class TestConverter implements vscode.Disposable {
         }
       })
     );
-
-    setTimeout(() => this.adapter.load(), 1);
   }
 
   public async refresh() {


### PR DESCRIPTION
The `TestHub` (the part of Test Explorer that connects registered adapters and controllers) already sends an initial `load()` request to each adapter and sends the resulting `TestLoadStarted`/`TestLoadFinished` events to all controllers (even if a controller is registered _after_ those events were sent by the adapter), so it's not necessary to send another `load()` request.