### PR TITLE
Always append messages to test output

### DIFF
--- a/src/testConverter.ts
+++ b/src/testConverter.ts
@@ -292,7 +292,7 @@ export class TestConverter implements vscode.Disposable {
         break;
     }
 
-    if (evt.message && ((evt.state !== 'errored' && evt.state !== 'failed') || !vscodeTest.uri)) {
+    if (evt.message) {
       task.appendOutput(evt.message.replace(/\r?\n/g, '\r\n'));
     }
   }


### PR DESCRIPTION
If a test has a `uri` and fails, there is nowhere in the VS Code UI that otherwise displays this output. This continues to fix #20 (test output seems to be lost) where in 63a7df7 the `!vscodeTest.uri` check was added because it was assumed the CMake Test Explorer would not associate a file with a test. However, there is an option to do so (`cmakeExplorer.testFileVar`), and when that is used there is no output anywhere to be seen when a test fails.