### PR TITLE
Support test result invalidation

### DIFF
--- a/src/testConverter.ts
+++ b/src/testConverter.ts
@@ -160,6 +160,16 @@ export class TestConverter implements vscode.Disposable {
         }
       })
     );
+    if (adapter.retire) {
+      this.disposables.push(adapter.retire(evt => {
+        if (evt.tests) {
+          const items = evt.tests.map(test => this.itemsById.get(test)).filter(item => !!item);
+          this.controller.invalidateTestResults(items);
+        } else {
+          this.controller.invalidateTestResults();
+        }
+      }));
+    }
   }
 
   public dispose() {


### PR DESCRIPTION
This is my second attempt to get this fix in. The last time (#9) it was first deferred and then replaced with #60 which only seems to trigger autorun on invalidation (that's my guess which I can't verify because native testing doesn't let me enable autorun for some reason) but it doesn't show the test result as invalidated in the UI (and that's the part that I need and also the reason why I keep using the old Test Explorer UI).