### PR TITLE
fix: duplicate messages on test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "arrowParens": "avoid"
   },
   "dependencies": {
+    "ansi-colors": "^4.1.3",
     "stacktrace-parser": "^0.1.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,6 +316,11 @@ ajv@^6.10.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ansi-colors@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"


### PR DESCRIPTION
- Don't show a (usually duplicate) message for test failures if
  'decoration' messages are also present.
- To avoid the risk of losing info, show console output for each test.
  Also show passed/failed state for each test while we're there.

![](https://memes.peet.io/img/24-11-b89e399b-6d50-410c-86d3-4d4304d96b80.png)